### PR TITLE
docs: simplify PR template Type of change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Type of change
 
-Select one: **Bug fix** | **New feature** | **Breaking change** | **Documentation update** | **Chore**
+Select one (delete the others): **Bug fix** | **New feature** | **Breaking change** | **Documentation update** | **Chore**. See [Conventional Commits](https://www.conventionalcommits.org/).
 
 ## Changes made
 


### PR DESCRIPTION
## Description

Simplifies the PR template "Type of change" section to avoid GitHub treating the 5 checkboxes as tasks (showing "5 of 9" when only the Checklist items should count). Adds instruction and Conventional Commits link.

## Type of change

Select one (delete the others): **Bug fix** | **New feature** | **Breaking change** | **Documentation update** | **Chore**. See [Conventional Commits](https://www.conventionalcommits.org/).

## Changes made

- Replace Type of change checkboxes with single-line "Select one (delete the others)" format
- Add link to Conventional Commits spec

## How to test

N/A — template change only.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have run `npm run check` and fixed any issues
- [x] I have updated the documentation if needed
- [x] I have added or updated tests for my changes