### PR TITLE
fix(ci): align Scorecard workflow with OSSF restrictions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,21 +7,15 @@ on:
   schedule:
     - cron: "30 1 * * 6"
 
-permissions:
-  contents: read
-  security-events: write
-  id-token: write
-  actions: write
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       security-events: write
       id-token: write
-      actions: write
 
     steps:
       - name: Checkout code
@@ -30,20 +24,20 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Description

Fixes the failing Scorecard analysis job (e.g. [run #13](https://github.com/knirski/paperless-ingestion-bot/actions/runs/22799451830)). The OSSF Scorecard API rejects workflow runs when the workflow violates its [workflow restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions), specifically "No workflow level write permissions."

## Type of change

**Bug fix**

## Changes made

- Use `permissions: read-all` at workflow level (removes write permissions that caused rejection)
- Keep only `security-events: write` and `id-token: write` at job level (required for code scanning + OIDC)
- Bump ossf/scorecard-action to v2.4.3
- Bump actions/upload-artifact to v6.0.0
- Bump github/codeql-action/upload-sarif to v4.32.0

## How to test

1. Merge this PR
2. Verify the Scorecard analysis workflow run succeeds on the next push to main

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have run `npm run check` and fixed any issues
- [ ] I have updated the documentation if needed
- [ ] I have added or updated tests for my changes

## Related issues

N/A