### PR TITLE
feat: add Codecov coverage badge and Test Analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,18 @@ jobs:
       - run: npm run check
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./test-report.junit.xml
 
   nix:
     if: github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ dist/
 .env.*
 .DS_Store
 coverage/
+test-report.junit.xml
 result
 .pr-body.md

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		setupFiles: ["./vitest.setup.ts"],
+		reporters: ["default", "junit"],
+		outputFile: { junit: "./test-report.junit.xml" },
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "text-summary", "lcov"],


### PR DESCRIPTION
## Description

Enables Codecov coverage badge and Test Analytics for the repository. The coverage badge was already in the README but required CI configuration and a token. This PR adds the full setup: coverage upload with token, JUnit test results for Test Analytics, and pins both actions to their latest versions.

## Type of change

**New feature**

## Changes made

- Add `CODECOV_TOKEN` to the coverage upload step (required for Codecov v5)
- Add JUnit reporter to Vitest config (outputs `test-report.junit.xml`)
- Add `codecov/test-results-action` step to upload test results for Test Analytics
- Pin `codecov-action` to v5.5.2 (was v4)
- Pin `test-results-action` to v1.2.1 with commit hash
- Add `test-report.junit.xml` to `.gitignore`

## How to test

1. Ensure `CODECOV_TOKEN` is set in GitHub repo secrets (Settings → Secrets)
2. Push and verify CI runs; coverage and test results upload steps should succeed
3. Check Codecov dashboard for coverage and Tests tab for analytics

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have run `npm run check` and fixed any issues
- [ ] I have updated the documentation if needed
- [ ] I have added or updated tests for my changes

## Related issues



## Breaking changes

N/A