### PR TITLE
chore: replace read-all with least-privilege in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,10 @@ on:
   schedule:
     - cron: "30 1 * * 6"
 
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
 
 jobs:
   analysis:


### PR DESCRIPTION
## Description

Replaces `permissions: read-all` with least-privilege permissions in the Scorecard workflow to improve OpenSSF Scorecard token-permissions check.

## Research findings

**OpenSSF Scorecard** evaluates GitHub Actions token permissions. `read-all` grants broad access; the token-permissions check rewards explicit, least-privilege grants.

**Required permissions for Scorecard workflow:**
- `contents: read` — checkout and read repo
- `security-events: write` — upload SARIF to code scanning
- `id-token: write` — OIDC for scorecard-action publish_results

Job-level overrides were redundant; workflow-level permissions suffice.

## Type of change

**Chore**. See [Conventional Commits](https://www.conventionalcommits.org/).

## Changes made

- Replace `permissions: read-all` with explicit `contents: read`, `security-events: write`, `id-token: write`

## How to test

1. Push and verify Scorecard workflow runs on next schedule or push to main
2. Check Scorecard results for token-permissions improvement

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have run `npm run check` and fixed any issues (N/A — workflow only)
- [ ] I have updated the documentation if needed
- [ ] I have added or updated tests for my changes

## Related issues

N/A

## Breaking changes

N/A