### PR TITLE
chore: add Cursor PR workflow rule and equivalent in AGENTS.md

### DIFF
--- a/.cursor/rules/pr-workflow.mdc
+++ b/.cursor/rules/pr-workflow.mdc
@@ -1,0 +1,15 @@
+---
+description: PR creation workflow — split changes logically, follow template, then checkout main and pull
+alwaysApply: true
+---
+
+# PR Creation Workflow
+
+When creating a pull request (GitHub MCP or `gh pr create`):
+
+1. **Assess changes** — Inspect uncommitted and committed-but-not-pushed changes. Divide and group them logically (e.g. feature vs docs vs chore). Create separate branches and separate PRs for each logical group.
+2. Create branch, commit, push
+3. Create PR — follow [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md)
+4. **Checkout main and pull** — `git checkout main && git pull`
+
+Do not finish until step 4 is done. The workspace must be left on `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,14 @@ Create small, focused commits. If changes span many files or concerns, propose s
 
 ## Pull Requests
 
-When creating a PR (e.g. with GitHub MCP or `gh pr create`), **follow the [PR template](.github/PULL_REQUEST_TEMPLATE.md)**. After creating the PR, **checkout `main` and pull** so the workspace is left on the default branch.
+When creating a PR (e.g. with GitHub MCP or `gh pr create`):
+
+1. **Assess changes** — Inspect uncommitted and committed-but-not-pushed changes. Divide and group them logically (e.g. feature vs docs vs chore). Create separate branches and separate PRs for each logical group.
+2. Create branch, commit, push
+3. Create PR — follow the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+4. **Checkout main and pull** — `git checkout main && git pull`. Do not finish until this is done; the workspace must be left on `main`.
+
+**PR body:** Include:
 
 1. **Description** — What and why (context, not just title restatement).
 2. **Type of change** — Check exactly one.


### PR DESCRIPTION
## Description

Adds a Cursor rule (`.cursor/rules/pr-workflow.mdc`) that defines the PR creation workflow and mirrors it in AGENTS.md so both Cursor and AI agents follow the same process.

## Type of change

**Chore**

## Changes made

- Add `.cursor/rules/pr-workflow.mdc` with 4-step PR workflow (create branch/commit/push, create PR per template, checkout main and pull)
- Update AGENTS.md Pull Requests section with equivalent workflow instructions

## How to test

1. Read `.cursor/rules/pr-workflow.mdc` and AGENTS.md Pull Requests section
2. Confirm both describe the same workflow
3. Run `npm run check` (no code changes)

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have run `npm run check` and fixed any issues
- [x] I have updated the documentation if needed
- [x] I have added or updated tests for my changes (N/A — docs only)

## Related issues

## Breaking changes